### PR TITLE
Make toArray support objects with public properties

### DIFF
--- a/src/NObjects/Object.php
+++ b/src/NObjects/Object.php
@@ -65,13 +65,20 @@ class Object
 
         // only reflect an object once
         static $props;
+        static $reflPropNames;
+
         if (empty($props[$class])) {
             $props[$class] = $this->__getAllReflectionProperties(new \ReflectionClass($this));
+            foreach($props[$class] as $prop) {
+                $reflPropNames[$class][$prop->getName()] = true;
+            }
         }
 
         // adding support for public properties
         foreach ($this as $k => $v) {
-            $props[$class][] = (object)array('name' => $k, 'value' => $v);
+            if (!isset($reflPropNames[$class][$k])) {
+                $props[$class][] = (object)array('name' => $k, 'value' => $v);
+            }
         }
 
         $array = array();
@@ -88,7 +95,7 @@ class Object
             }
 
             // if public use temp object and don't cache
-            if (isset($this->{$rp->name})) {
+            if (!isset($reflPropNames[$class][$rp->name]) && isset($this->{$rp->name})) {
                 $val = $rp->value;
                 unset($props[$class]);
             } else {

--- a/tests/NObjects/ObjectTest.php
+++ b/tests/NObjects/ObjectTest.php
@@ -70,6 +70,19 @@ class ObjectTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('test' => 1212), $obj4->toArray()); // value for empty key ignored
     }
 
+    public function testObjectHelpersWithPublicPropsAndSetters()
+    {
+        $data = array('bar' => '1212');
+        $obj = new FooFour();
+        $obj->fromArray($data);
+
+        $this->assertEquals('1212', $obj->getBar());
+        $this->assertEquals('1212', $obj->bar);
+
+        $outData = $obj->toArray();
+        $this->assertEquals(array('bar' => '1212'), $outData);
+    }
+
     public function testAncestors()
     {
         $ancestors = Object::ancestors('Object');
@@ -269,4 +282,25 @@ class FooThree extends Object
         return $this->bar;
     }
 
+}
+
+class FooFour extends Object
+{
+
+    public $bar;
+
+    public function setBar($bar)
+    {
+        $this->bar = $bar;
+        return $this;
+    }
+
+
+    /**
+     * @return mixed
+     */
+    public function getBar()
+    {
+        return $this->bar;
+    }
 }


### PR DESCRIPTION
This makes it so that toArray() will support objects with public properties that are defined in the class, instead of dynamic properties.
